### PR TITLE
Update copper_funnel.json

### DIFF
--- a/src/main/resources/data/scf/recipes/copper_funnel.json
+++ b/src/main/resources/data/scf/recipes/copper_funnel.json
@@ -13,7 +13,7 @@
     },
 
     "C": {
-      "item": "c:copper_ingot"
+      "item": "minecraft:copper_ingot"
     }
   },
   "result": {


### PR DESCRIPTION
Minecraft now has copper ingots and you can use this recipe again.